### PR TITLE
fix: adding profiler feature in the console log

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -57,7 +57,7 @@ macro_rules! embed_to_wasm {
             cs.set_constraints(&$synthesizer);
             *circuit = cs.to_r1cs();
 
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(all(target_arch = "wasm32", feature = "profiler"))]
             {
                 web_sys::console::log_1(&JsValue::from_str("Num constraints:"));
                 web_sys::console::log_1(&JsValue::from_f64(cs.num_constraints.unwrap() as f64));


### PR DESCRIPTION
This PR adds `profiler` feature for the "Num constraints:" console log statement in the `wasm.rs` so that when built a wasm-pkg in production it doesn't show it. Thanks. 